### PR TITLE
Improve string interpolation

### DIFF
--- a/AzureDevops.sublime-syntax
+++ b/AzureDevops.sublime-syntax
@@ -2,8 +2,10 @@
 ---
 # See http://www.sublimetext.com/docs/3/syntax.html
 scope: source.yaml.pipeline.azure-devops
-extends: Packages/YamlPipelines/YamlPipeline.sublime-syntax
 version: 2
+
+extends: Packages/YamlPipelines/YamlPipeline.sublime-syntax
+
 file_extensions:
   - azure-pipeline.yml
 

--- a/AzureDevops.sublime-syntax
+++ b/AzureDevops.sublime-syntax
@@ -35,7 +35,28 @@ contexts:
         - include: flow-scalar-plain-out-body
         - include: inside-expression
 
-  expression-begin:
+  string-interpolations:
+    # https://learn.microsoft.com/en-us/azure/devops/pipelines/process/expressions?view=azure-devops
+    - meta_prepend: true
+    - match: \$\(
+      scope: punctuation.definition.variable.begin.pipeline
+      push: inside-ado-variable-reference-string-interpolation
+    - match: \$\[
+      scope: punctuation.section.block.begin.pipeline
+      push: inside-ado-runtime-expression-string-interpolations
+
+  inside-ado-variable-reference-string-interpolation:
+    - clear_scopes: 1  # clear string scope
+    - meta_scope: meta.interpolation.pipeline
+    - meta_content_scope: variable.other.constant.pipeline
+    - include: inside-ado-variable-reference
+
+  inside-ado-runtime-expression-string-interpolations:
+    - clear_scopes: 1  # clear string scope
+    - meta_scope: meta.interpolation.pipeline meta.block.pipeline
+    - include: inside-ado-runtime-expression
+
+  interpolations:
     # https://learn.microsoft.com/en-us/azure/devops/pipelines/process/expressions?view=azure-devops
     - meta_prepend: true
     - match: \$\(
@@ -46,12 +67,14 @@ contexts:
       push: inside-ado-runtime-expression
 
   inside-ado-variable-reference:
+    - meta_scope: meta.interpolation.pipeline
     - meta_content_scope: variable.other.constant.pipeline
     - match: \)
       scope: punctuation.definition.variable.end.pipeline
       pop: 1
 
   inside-ado-runtime-expression:
+    - meta_scope: meta.interpolation.pipeline meta.block.pipeline
     - match: \]
       scope: punctuation.section.block.end.pipeline
       pop: 1
@@ -59,7 +82,7 @@ contexts:
 
   inside-expression:
     - meta_append: true
-    - include: expression-begin
+    - include: interpolations
     - include: context
     - match: \b(?i:true|false)\b
       scope: constant.language.boolean.pipeline

--- a/AzureDevops.sublime-syntax
+++ b/AzureDevops.sublime-syntax
@@ -49,12 +49,12 @@ contexts:
     - meta_content_scope: variable.other.constant.pipeline
     - match: \)
       scope: punctuation.definition.variable.end.pipeline
-      pop: true
+      pop: 1
 
   inside-ado-runtime-expression:
     - match: \]
       scope: punctuation.section.block.end.pipeline
-      pop: true
+      pop: 1
     - include: inside-expression
 
   inside-expression:

--- a/Bash (AzureDevops).sublime-syntax
+++ b/Bash (AzureDevops).sublime-syntax
@@ -2,9 +2,10 @@
 ---
 # See http://www.sublimetext.com/docs/3/syntax.html
 scope: source.shell.bash.azure-devops
-extends: Packages/ShellScript/Bash.sublime-syntax
 version: 2
 hidden: true
+
+extends: Packages/ShellScript/Bash.sublime-syntax
 
 contexts:
   string-quoted-double-body:

--- a/Bash (AzureDevops).sublime-syntax
+++ b/Bash (AzureDevops).sublime-syntax
@@ -8,10 +8,11 @@ hidden: true
 extends: Packages/ShellScript/Bash.sublime-syntax
 
 contexts:
-  string-quoted-double-body:
-    - meta_prepend: true
-    - include: scope:source.yaml.pipeline.azure-devops#expression-begin
 
-  string-quoted-single-body:
+  expansions-parameter:
     - meta_prepend: true
-    - include: scope:source.yaml.pipeline.azure-devops#expression-begin
+    - include: scope:source.yaml.pipeline.azure-devops#interpolations
+
+  string-prototype:
+    - meta_prepend: true
+    - include: scope:source.yaml.pipeline.azure-devops#string-interpolations

--- a/Bash (Github Actions).sublime-syntax
+++ b/Bash (Github Actions).sublime-syntax
@@ -8,17 +8,13 @@ hidden: true
 extends: Packages/ShellScript/Bash.sublime-syntax
 
 contexts:
-  string-quoted-double-body:
+  expansions-parameter:
     - meta_prepend: true
-    - include: scope:source.yaml.pipeline.github-actions#expression-begin
+    - include: scope:source.yaml.pipeline.github-actions#interpolations
 
-  string-quoted-single-body:
+  string-prototype:
     - meta_prepend: true
-    - include: scope:source.yaml.pipeline.github-actions#expression-begin
-
-  cmd-args:
-    - meta_prepend: true
-    - include: scope:source.yaml.pipeline.github-actions#expression-begin
+    - include: scope:source.yaml.pipeline.github-actions#string-interpolations
 
   heredocs-body:
     - meta_prepend: true

--- a/Bash (Github Actions).sublime-syntax
+++ b/Bash (Github Actions).sublime-syntax
@@ -2,9 +2,10 @@
 ---
 # See http://www.sublimetext.com/docs/3/syntax.html
 scope: source.shell.bash.github-actions
-extends: Packages/ShellScript/Bash.sublime-syntax
 version: 2
 hidden: true
+
+extends: Packages/ShellScript/Bash.sublime-syntax
 
 contexts:
   string-quoted-double-body:

--- a/Github Actions.sublime-syntax
+++ b/Github Actions.sublime-syntax
@@ -2,8 +2,9 @@
 ---
 # See http://www.sublimetext.com/docs/3/syntax.html
 scope: source.yaml.pipeline.github-actions
-extends: Packages/YamlPipelines/YamlPipeline.sublime-syntax
 version: 2
+
+extends: Packages/YamlPipelines/YamlPipeline.sublime-syntax
 
 contexts:
   node:

--- a/Github Actions.sublime-syntax
+++ b/Github Actions.sublime-syntax
@@ -36,7 +36,6 @@ contexts:
     - include: inside-expression
 
   inside-expression:
-    - meta_include_prototype: false
     - meta_append: true
     # https://docs.github.com/en/actions/learn-github-actions/expressions
     - include: context

--- a/Kong.sublime-syntax
+++ b/Kong.sublime-syntax
@@ -23,7 +23,7 @@ contexts:
     - include: comment
     - include: paths-block-sequence
     - match: ^
-      pop: true
+      pop: 1
 
   paths-block-sequence:
     # http://www.yaml.org/spec/1.2/spec.html#style/block/sequence

--- a/Kong.sublime-syntax
+++ b/Kong.sublime-syntax
@@ -1,11 +1,14 @@
 %YAML 1.2
 ---
 # See http://www.sublimetext.com/docs/syntax.html
+scope: source.yaml.kong
+version: 2
+
+extends: Packages/YAML/YAML.sublime-syntax
+
 file_extensions:
   - kong.yml
-scope: source.yaml.kong
-extends: Packages/YAML/YAML.sublime-syntax
-version: 2
+
 contexts:
   main:
     - meta_prepend: true

--- a/YamlPipeline.sublime-syntax
+++ b/YamlPipeline.sublime-syntax
@@ -10,16 +10,27 @@ extends: Packages/YAML/YAML.sublime-syntax
 contexts:
   flow-scalar-plain-out-body:
     - meta_prepend: true
-    - include: expression-begin
+    - include: string-interpolations
 
-  expression-begin:
+  string-interpolations:
+    - match: \$\{\{
+      scope: punctuation.section.block.begin.pipeline
+      push: inside-string-interpolations
+
+  inside-string-interpolations:
+    - clear_scopes: 1
+    - meta_include_prototype: false
+    - meta_scope: meta.interpolation.pipeline meta.block.pipeline
+    - include: inside-expression
+
+  interpolations:
     - match: \$\{\{
       scope: punctuation.section.block.begin.pipeline
       push: inside-expression
 
   inside-expression:
     - meta_include_prototype: false
-    - meta_content_scope: meta.interpolation.pipeline
+    - meta_scope: meta.interpolation.pipeline meta.block.pipeline
     - match: \}\}
       scope: punctuation.section.block.end.pipeline
       pop: 1
@@ -71,6 +82,7 @@ contexts:
       pop: 1
 
   embedded-bash:
+    - clear_scopes: 1
     - meta_include_prototype: false
 
   script-block-scalar-begin:

--- a/YamlPipeline.sublime-syntax
+++ b/YamlPipeline.sublime-syntax
@@ -2,9 +2,10 @@
 ---
 # See http://www.sublimetext.com/docs/3/syntax.html
 scope: source.yaml.pipeline
-extends: Packages/YAML/YAML.sublime-syntax
 version: 2
 hidden: true
+
+extends: Packages/YAML/YAML.sublime-syntax
 
 contexts:
   flow-scalar-plain-out-body:

--- a/YamlPipeline.sublime-syntax
+++ b/YamlPipeline.sublime-syntax
@@ -8,6 +8,14 @@ hidden: true
 extends: Packages/YAML/YAML.sublime-syntax
 
 contexts:
+  flow-scalar-double-quoted-body:
+    - meta_prepend: true
+    - include: string-interpolations
+
+  flow-scalar-single-quoted-body:
+    - meta_prepend: true
+    - include: string-interpolations
+
   flow-scalar-plain-out-body:
     - meta_prepend: true
     - include: string-interpolations

--- a/YamlPipeline.sublime-syntax
+++ b/YamlPipeline.sublime-syntax
@@ -22,7 +22,7 @@ contexts:
     - meta_content_scope: meta.interpolation.pipeline
     - match: \}\}
       scope: punctuation.section.block.end.pipeline
-      pop: true
+      pop: 1
     - match: \b(?:true|false)\b
       scope: constant.language.boolean.pipeline
     - match: \b(\w+)\s*(\()
@@ -82,7 +82,7 @@ contexts:
       escape: ^(?!\1|\s*$)
       pop: 1
     - match: ^(?=\S)  # the block is empty
-      pop: true
+      pop: 1
     - include: comment  # include comments but not properties
     - match: .+
       scope: invalid.illegal.expected-comment-or-newline.yaml
@@ -95,12 +95,12 @@ contexts:
       scope: punctuation.accessor.begin.pipeline
       push: inside-property-index
     - match: ''
-      pop: true
+      pop: 1
 
   inside-property-index:
     - match: \]
       scope: punctuation.accessor.end.pipeline
-      pop: true
+      pop: 1
     - include: variable-access
     - include: strings
     # TODO: use use inside-expression instead?
@@ -110,7 +110,7 @@ contexts:
       scope: variable.other.member.pipeline
       set: possible-accessor
     # - match: ''
-    #   pop: true
+    #   pop: 1
 
   strings:
     - match: \'
@@ -125,5 +125,5 @@ contexts:
       scope: constant.character.escape.pipeline
     - match: \'
       scope: punctuation.definition.string.end.pipeline
-      pop: true
+      pop: 1
 

--- a/tests/syntax_test_github_actions.yml
+++ b/tests/syntax_test_github_actions.yml
@@ -110,7 +110,13 @@ jobs:
 #                                    ^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.single
 #                                                             ^ punctuation.definition.string.end
 
-      - name: Get binary for ${{ matrix.sublime-channel }} build ${{ matrix.sublime-build }}
+      - name: "Get binary for ${{ matrix.sublime-channel }} build ${{ matrix.sublime-build }}"
+        #     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.yaml
+        #     ^^^^^^^^^^^^^^^^ string.quoted.double.yaml - meta.interpolation
+        #                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.interpolation.pipeline meta.block.pipeline - string
+        #                                                  ^^^^^^^ string.quoted.double.yaml - meta.interpolation
+        #                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.interpolation.pipeline meta.block.pipeline - string
+        #                                                                                    ^ string.quoted.double.yaml punctuation.definition.string.end.yaml - meta.interpolation
         run: |
           if [[ "${{ matrix.sublime-build }}" == "latest" ]]; then
           #  ^^ support.function.test.begin

--- a/tests/syntax_test_github_actions.yml
+++ b/tests/syntax_test_github_actions.yml
@@ -34,6 +34,9 @@ jobs:
 # ^^^^^^^^^^^^^^^^ entity.name.function.github-actions
 #                 ^ punctuation.separator.key-value.yaml
     name: Test on ${{ matrix.sublime-channel }} build
+    #     ^^^^^^^^ meta.string.yaml string.unquoted.plain.out.yaml
+    #             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.yaml meta.interpolation.pipeline meta.block.pipeline - string
+    #                                          ^^^^^^ meta.string.yaml string.unquoted.plain.out.yaml
     #             ^^^ punctuation.section.block.begin
     #                 ^^^^^^ constant.language.context
     #                       ^ punctuation.accessor.dot
@@ -46,6 +49,7 @@ jobs:
 #         ^^^^^^^^ meta.function-call.identifier support.function
 # TODO: scope quotes correctly in `if` above
     if: ${{ !contains(github.event.head_commit.message, 'SKIP SCRIPTS') }}
+#       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.yaml meta.interpolation.pipeline meta.block.pipeline - string.unquoted
 #       ^^^ punctuation.section.block.begin
 #           ^ keyword.operator.logical
 #            ^^^^^^^^ meta.function-call.identifier support.function


### PR DESCRIPTION
Fixes #3

_I am keen enough to add PRs via branches into this repo instead of forking it. Is it ok?_

This PR suggests

1. some syntax version 2 related formal changes. 
2. to implement variable interpolation by clearing possible `string` scopes

It uses an approach already used for Makefile.sublime-syntax.

Note: It requires https://github.com/sublimehq/Packages/pull/3629

It should add proper interpolation to (most/all?) quoted and unquoted strings in YAML and Bash.


With regards to scoping interpolations, we run into the same issue as outlined in https://github.com/sublimehq/Packages/pull/3669#pullrequestreview-1314647168 however.