### PR TITLE
Expand path pattern based pipeline syntax detection

### DIFF
--- a/set_syntax_on_load_or_save.py
+++ b/set_syntax_on_load_or_save.py
@@ -2,6 +2,16 @@ import sublime
 import sublime_plugin
 from pathlib import Path
 
+# Some CI pipeline scopes can be deduced from their path when given more context
+# than just an extension. This maps a given path pattern to a scope to apply.
+# The first one that matches will be applied (note that dicts are
+# insertion-ordered as of Python 3.7), but in general they should not overlap.
+SCOPE_PATH_PATTERNS = {
+    '**/.github/workflows/**': 'scope:source.yaml.pipeline.github-actions',
+    '**/.github/actions/**/*': 'scope:source.yaml.pipeline.github-actions',
+    '*.gitlab-ci.yml': 'scope:source.yaml.pipeline.gitlab',
+}
+
 
 class YamlFileOpenedEventListener(sublime_plugin.ViewEventListener):
     @classmethod
@@ -16,5 +26,7 @@ class YamlFileOpenedEventListener(sublime_plugin.ViewEventListener):
 
     def set_syntax_if_filepath_applicable(self):
         if filename := self.view.file_name():
-            if Path(filename).match('**/.github/workflows/**'):
-                self.view.assign_syntax('scope:source.yaml.pipeline.github-actions')
+            for pattern, scope in SCOPE_PATH_PATTERNS.items():
+                if Path(filename).match(pattern):
+                    self.view.assign_syntax(scope)
+                    break


### PR DESCRIPTION
I wanted to add detection for a couple of common conventions:

1. Gitlab CI config is often decomposed into files _ending_ with `.gitlab-ci.yml`. For example, [these templates](https://gitlab.com/gitlab-org/gitlab-foss/-/tree/0905e6bd5042fa84fe66736eb9ab1be94c3d8aa9/lib/gitlab/ci/templates). Sublime Text's `file_extensions` key does not allow for this.
2. Github [composite actions](https://docs.github.com/en/actions/creating-actions/creating-a-composite-action), which live alongside workflow files. They are nested one level deeper, so I had to make the pattern `**/*` instead of `**`.

This meant expanding the path-pattern-based detection of syntax to use a mapping.