### PR TITLE
Add `.gitlab-ci.yml` extension

### DIFF
--- a/Gitlab CICD.sublime-syntax
+++ b/Gitlab CICD.sublime-syntax
@@ -8,6 +8,7 @@ extends: Packages/YamlPipelines/YamlPipeline.sublime-syntax
 
 file_extensions:
   - .gitlab-ci.yml
+  - gitlab-ci.yml
 
 variables:
   global_keywords: |-


### PR DESCRIPTION
Besides the main `.gitlab-ci.yml` file, templates are commonly named `<name>.gitlab-ci.yml`, which requires a separate entry in `file_extensions`.

See also the documentation: https://docs.gitlab.com/ee/ci/examples/#cicd-templates