### PR TITLE
Suggestion to folded bash blocks

### DIFF
--- a/AzureDevops.sublime-syntax
+++ b/AzureDevops.sublime-syntax
@@ -93,14 +93,11 @@ contexts:
       push: possible-accessor
 
   embedded-bash:
-    - meta_append: true
-    - match: ''
-      embed: scope:source.shell.bash.azure-devops
-      escape: (?!)
+    - meta_include_prototype: false
+    - meta_scope: source.shell.bash.embedded
+    - include: scope:source.shell.bash.azure-devops
 
   embedded-bash-folded:
-    - meta_append: true
-    - match: ''
-      push: scope:source.shell.bash.azure-devops
-      with_prototype:
-        - include: swallow-newlines
+    - meta_include_prototype: false
+    - meta_scope: source.shell.bash.embedded
+    - include: scope:source.shell.bash.folded-azure-devops

--- a/Bash (AzureDevops Folded).sublime-syntax
+++ b/Bash (AzureDevops Folded).sublime-syntax
@@ -1,0 +1,10 @@
+%YAML 1.2
+---
+# See http://www.sublimetext.com/docs/3/syntax.html
+scope: source.shell.bash.folded-azure-devops
+version: 2
+hidden: true
+
+extends:
+  - Bash (AzureDevops).sublime-syntax
+  - Bash (Folded).sublime-syntax

--- a/Bash (Folded).sublime-syntax
+++ b/Bash (Folded).sublime-syntax
@@ -1,0 +1,11 @@
+%YAML 1.2
+---
+# See http://www.sublimetext.com/docs/3/syntax.html
+scope: source.shell.bash.folded
+version: 2
+hidden: true
+
+extends: Packages/ShellScript/Bash.sublime-syntax
+
+contexts:
+  eol-pop: []

--- a/Bash (Github Actions Folded).sublime-syntax
+++ b/Bash (Github Actions Folded).sublime-syntax
@@ -1,0 +1,10 @@
+%YAML 1.2
+---
+# See http://www.sublimetext.com/docs/3/syntax.html
+scope: source.shell.bash.folded-github-actions
+version: 2
+hidden: true
+
+extends:
+  - Bash (Github Actions).sublime-syntax
+  - Bash (Folded).sublime-syntax

--- a/Github Actions.sublime-syntax
+++ b/Github Actions.sublime-syntax
@@ -71,18 +71,13 @@ contexts:
 
   embedded-bash:
     - meta_include_prototype: false
-    - meta_append: true
-    - match: ''
-      embed: scope:source.shell.bash.github-actions
-      escape: (?!)
+    - meta_scope: source.shell.bash.embedded
+    - include: scope:source.shell.bash.github-actions
 
   embedded-bash-folded:
     - meta_include_prototype: false
-    - meta_append: true
-    - match: ''
-      push: scope:source.shell.bash.github-actions
-      with_prototype:
-        - include: swallow-newlines
+    - meta_scope: source.shell.bash.embedded
+    - include: scope:source.shell.bash.folded-github-actions
 
   expect-jobs:
     - match: ^(\s*)([\w\-]+)\s*(:)(?=\s|$)

--- a/Gitlab CICD.sublime-syntax
+++ b/Gitlab CICD.sublime-syntax
@@ -54,14 +54,11 @@ contexts:
       pop: 1
 
   embedded-bash:
-    - meta_append: true
-    - match: ''
-      embed: scope:source.shell.bash
-      escape: (?!)
+    - meta_include_prototype: false
+    - meta_scope: source.shell.bash.embedded
+    - include: scope:source.shell.bash
 
   embedded-bash-folded:
-    - meta_append: true
-    - match: ''
-      push: scope:source.shell.bash
-      with_prototype:
-        - include: swallow-newlines
+    - meta_include_prototype: false
+    - meta_scope: source.shell.bash.embedded
+    - include: scope:source.shell.bash.folded

--- a/YamlPipeline.sublime-syntax
+++ b/YamlPipeline.sublime-syntax
@@ -97,10 +97,6 @@ contexts:
       escape: '{{_flow_scalar_end_plain_out}}'
       pop: 1
 
-  embedded-bash:
-    #- clear_scopes: 1
-    - meta_include_prototype: false
-
   script-block-scalar-begin:
     - meta_include_prototype: false
     - include: comment
@@ -171,13 +167,8 @@ contexts:
       scope: punctuation.definition.string.end.pipeline
       pop: 1
 
-  embedded-bash-folded:
+  embedded-bash:
     - meta_include_prototype: false
 
-  swallow-newlines:
-    - match: \n
-      push: swallowing-newline
-
-  swallowing-newline:
-    - match: ^
-      pop: 1
+  embedded-bash-folded:
+    - meta_include_prototype: false

--- a/tests/syntax_test_github_actions.yml
+++ b/tests/syntax_test_github_actions.yml
@@ -231,3 +231,21 @@ jobs:
         run: |
           echo '# Some Markdown Content Here' >> $GITHUB_STEP_SUMMARY
 #                                                ^^^^^^^^^^^^^^^^^^^^ variable.language.github-actions
+
+      - name: folded shell script command
+        run: >-
+          mvn
+          --batch-mode
+          # ^^^^^^^^^^ source.shell meta.function-call.arguments meta.parameter.option variable.parameter.option
+          $MAVEN_CLI_OPTS_DEFAULT
+          $MAVEN_CLI_OPTS
+          $MAVEN_GITFLOW_CLI_OPTS
+          gitflow:release-finish
+          # ^^^^^^^^^^^^^^^^^^^^^ source.shell meta.function-call.arguments - variable
+          -DpushRemote=true
+          -DreleaseVersion="${NEW_VERSION}"
+          #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.shell meta.function-call.arguments
+          #               ^ keyword.operator.assignment
+          #                ^^^^^^^^^^^^^^^^ meta.string
+          #                   ^^^^^^^^^^^ meta.interpolation.parameter variable.other.readwrite
+          -DskipTestProject=true

--- a/tests/syntax_test_gitlab_cicd.yml
+++ b/tests/syntax_test_gitlab_cicd.yml
@@ -150,6 +150,6 @@ release-finish:
       -DreleaseVersion="${NEW_VERSION}"
       #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.shell meta.function-call.arguments
       #               ^ keyword.operator.assignment
-      #                ^^^^^^^^^^^^^^^^^ meta.string
+      #                ^^^^^^^^^^^^^^^^ meta.string
       #                   ^^^^^^^^^^^ meta.interpolation.parameter variable.other.readwrite
       -DskipTestProject=true


### PR DESCRIPTION
Maybe use a separate `Bash (Folded).sublime-syntax` which just disables `eol-pop` and thus would countain just one command no matter how many lines the syntax has.

Based on this one create other extended syntaxes for DevOps and Actions.

Instead of embedding, they are just included into `embedd-bash` and `embedded-bash-folded`, because relevant contexts/patterns are used in those files only. So their compiled patterns are added to the including syntax, but none is created for the Bash syntaxes itself - as long as noone else uses them directly somehow.