### PR TITLE
Support GitLab references

### DIFF
--- a/Gitlab CICD.sublime-syntax
+++ b/Gitlab CICD.sublime-syntax
@@ -66,7 +66,7 @@ contexts:
 
   property:
     - meta_prepend: true
-    - match: (!reference\b)\s*(\[)
+    - match: (!reference)\s*(\[)
       captures:
         1: meta.property.yaml storage.type.tag-handle.yaml
         2: meta.sequence.flow.yaml punctuation.definition.sequence.begin.yaml
@@ -87,7 +87,7 @@ contexts:
 
   gitlab-after-reference:
     - match: \w+
-      scope: constant.other.gitlab
+      scope: keyword.other.gitlab
     - match: ','
       scope: punctuation.separator.sequence.yaml
       set: gitlab-after-reference-type

--- a/Gitlab CICD.sublime-syntax
+++ b/Gitlab CICD.sublime-syntax
@@ -39,6 +39,12 @@ contexts:
         2: punctuation.separator.key-value.yaml
 
   script-block-sequence:
+    - match: (-)[ \t]+(!reference\b)\s*(\[)
+      captures:
+        1: punctuation.definition.block.sequence.item.yaml
+        2: meta.property.yaml storage.type.tag-handle.yaml
+        3: meta.sequence.flow.yaml punctuation.definition.sequence.begin.yaml
+      push: script-reference-flow-sequence-body
     - match: (-)[ \t]+(?=\S)
       captures:
         1: punctuation.definition.block.sequence.item.yaml
@@ -63,3 +69,32 @@ contexts:
     - meta_include_prototype: false
     - meta_scope: source.shell.bash.embedded
     - include: scope:source.shell.bash.folded
+
+  script-reference-flow-sequence-body:
+    - meta_content_scope: meta.sequence.flow.yaml
+    - match: \]
+      scope: meta.sequence.flow.yaml punctuation.definition.sequence.end.yaml
+      pop: 1
+    - match: ','
+      scope: punctuation.separator.sequence.yaml
+      push: after-reference
+    - match: '[-\w.]+'
+      scope: constant.other.label.gitlab
+    - include: flow-pair-no-clear
+    - include: flow-node-11
+
+  after-reference:
+    - match: \w+
+      scope: constant.other.gitlab
+    - match: ','
+      scope: punctuation.separator.sequence.yaml
+      set: after-reference-type
+    - match: (?=\])
+      pop: 1
+
+  after-reference-type:
+    - match: \w+
+      scope: variable.other.constant.gitlab
+      pop: 1
+    - match: (?=\S)
+      pop: 1

--- a/Gitlab CICD.sublime-syntax
+++ b/Gitlab CICD.sublime-syntax
@@ -39,12 +39,6 @@ contexts:
         2: punctuation.separator.key-value.yaml
 
   script-block-sequence:
-    - match: (-)[ \t]+(!reference\b)\s*(\[)
-      captures:
-        1: punctuation.definition.block.sequence.item.yaml
-        2: meta.property.yaml storage.type.tag-handle.yaml
-        3: meta.sequence.flow.yaml punctuation.definition.sequence.begin.yaml
-      push: script-reference-flow-sequence-body
     - match: (-)[ \t]+(?=\S)
       captures:
         1: punctuation.definition.block.sequence.item.yaml
@@ -70,29 +64,37 @@ contexts:
     - meta_scope: source.shell.bash.embedded
     - include: scope:source.shell.bash.folded
 
-  script-reference-flow-sequence-body:
+  property:
+    - meta_prepend: true
+    - match: (!reference\b)\s*(\[)
+      captures:
+        1: meta.property.yaml storage.type.tag-handle.yaml
+        2: meta.sequence.flow.yaml punctuation.definition.sequence.begin.yaml
+      push: gitlab-reference-flow-sequence-body
+
+  gitlab-reference-flow-sequence-body:
     - meta_content_scope: meta.sequence.flow.yaml
     - match: \]
       scope: meta.sequence.flow.yaml punctuation.definition.sequence.end.yaml
       pop: 1
     - match: ','
       scope: punctuation.separator.sequence.yaml
-      push: after-reference
+      push: gitlab-after-reference
     - match: '[-\w.]+'
       scope: constant.other.label.gitlab
     - include: flow-pair-no-clear
     - include: flow-node-11
 
-  after-reference:
+  gitlab-after-reference:
     - match: \w+
       scope: constant.other.gitlab
     - match: ','
       scope: punctuation.separator.sequence.yaml
-      set: after-reference-type
+      set: gitlab-after-reference-type
     - match: (?=\])
       pop: 1
 
-  after-reference-type:
+  gitlab-after-reference-type:
     - match: \w+
       scope: variable.other.constant.gitlab
       pop: 1

--- a/Gitlab CICD.sublime-syntax
+++ b/Gitlab CICD.sublime-syntax
@@ -91,12 +91,17 @@ contexts:
     - match: ','
       scope: punctuation.separator.sequence.yaml
       set: gitlab-after-reference-type
+    - include: flow-pair-no-clear
+    - include: flow-node-11
     - match: (?=\])
       pop: 1
 
   gitlab-after-reference-type:
     - match: \w+
       scope: variable.other.constant.gitlab
-      pop: 1
+    - match: ','
+      scope: punctuation.separator.sequence.yaml
+    - include: flow-pair-no-clear
+    - include: flow-node-11
     - match: (?=\S)
       pop: 1

--- a/tests/syntax_test_gitlab_cicd.yml
+++ b/tests/syntax_test_gitlab_cicd.yml
@@ -170,7 +170,7 @@ test:
 #                ^ punctuation.definition.sequence.begin
 #                 ^^^^^^ constant.other.label
 #                       ^ punctuation.separator.sequence
-#                         ^^^^^^ constant.other
+#                         ^^^^^^ keyword.other
 #                               ^ punctuation.definition.sequence.end
 #                                ^ - meta.sequence
     - echo running my own command
@@ -197,8 +197,26 @@ test-vars-2:
     #                  ^ punctuation.definition.sequence.begin
     #                   ^^^^^ constant.other.label
     #                        ^ punctuation.separator.sequence
-    #                          ^^^^^^^^^ constant.other
+    #                          ^^^^^^^^^ keyword.other
     #                                   ^ punctuation.separator.sequence
     #                                     ^^^^^^^^^^^^^ variable.other.constant
   script:
     - printenv
+
+job1:
+  artifacts:
+    paths:
+      - binaries/
+      - .config
+
+job2:
+  artifacts:
+    paths: !reference [job1, artifacts, paths]
+#          ^^^^^^^^^^ meta.property storage.type.tag-handle
+#                     ^^^^^^^^^^^^^^^^^^^^^^^^ meta.sequence.flow
+#                      ^^^^ constant.other.label
+#                          ^ punctuation.separator.sequence
+#                            ^^^^^^^^^ keyword.other
+#                                     ^ punctuation.separator.sequence
+#                                       ^^^^^ variable.other.constant
+#                                            ^ punctuation.definition.sequence.end

--- a/tests/syntax_test_gitlab_cicd.yml
+++ b/tests/syntax_test_gitlab_cicd.yml
@@ -153,3 +153,44 @@ release-finish:
       #                ^^^^^^^^^^^^^^^^ meta.string
       #                   ^^^^^^^^^^^ meta.interpolation.parameter variable.other.readwrite
       -DskipTestProject=true
+
+include:
+  - local: setup.yml
+
+.teardown:
+  after_script:
+    - echo deleting environment
+
+test:
+  script:
+    - !reference [.setup, script]
+#   ^ punctuation.definition.block.sequence.item
+#     ^^^^^^^^^^ meta.property storage.type.tag-handle
+#                ^^^^^^^^^^^^^^^^ meta.sequence.flow
+#                ^ punctuation.definition.sequence.begin
+#                 ^^^^^^ constant.other.label
+#                       ^ punctuation.separator.sequence
+#                         ^^^^^^ constant.other
+#                               ^ punctuation.definition.sequence.end
+#                                ^ - meta.sequence
+    - echo running my own command
+#   ^ meta.block.script punctuation.definition.block.sequence.item
+#     ^^^^ source.shell.bash meta.function-call.identifier support.function.echo
+  after_script:
+    - !reference [.teardown, after_script]
+
+.vars:
+  variables:
+    URL: "http://my-url.internal"
+    IMPORTANT_VAR: "the details"
+
+test-vars-1:
+  variables: !reference [.vars, variables]
+  script:
+    - printenv
+
+test-vars-2:
+  variables:
+    MY_VAR: !reference [.vars, variables, IMPORTANT_VAR]
+  script:
+    - printenv

--- a/tests/syntax_test_gitlab_cicd.yml
+++ b/tests/syntax_test_gitlab_cicd.yml
@@ -192,5 +192,13 @@ test-vars-1:
 test-vars-2:
   variables:
     MY_VAR: !reference [.vars, variables, IMPORTANT_VAR]
+    #       ^^^^^^^^^^ meta.property storage.type.tag-handle
+    #                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.sequence.flow
+    #                  ^ punctuation.definition.sequence.begin
+    #                   ^^^^^ constant.other.label
+    #                        ^ punctuation.separator.sequence
+    #                          ^^^^^^^^^ constant.other
+    #                                   ^ punctuation.separator.sequence
+    #                                     ^^^^^^^^^^^^^ variable.other.constant
   script:
     - printenv

--- a/tests/syntax_test_gitlab_cicd.yml
+++ b/tests/syntax_test_gitlab_cicd.yml
@@ -211,12 +211,14 @@ job1:
 
 job2:
   artifacts:
-    paths: !reference [job1, artifacts, paths]
+    paths: !reference [job1, artifacts, paths, further_nesting]
 #          ^^^^^^^^^^ meta.property storage.type.tag-handle
-#                     ^^^^^^^^^^^^^^^^^^^^^^^^ meta.sequence.flow
+#                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.sequence.flow
 #                      ^^^^ constant.other.label
 #                          ^ punctuation.separator.sequence
 #                            ^^^^^^^^^ keyword.other
 #                                     ^ punctuation.separator.sequence
 #                                       ^^^^^ variable.other.constant
-#                                            ^ punctuation.definition.sequence.end
+#                                            ^ punctuation.separator.sequence
+#                                              ^^^^^^^^^^^^^^^ variable.other.constant
+#                                                             ^ punctuation.definition.sequence.end


### PR DESCRIPTION
fixes #18

not sure about scopes though - I consider the first sequence item to be a reference to a label, like a `goto` in programming languages. The second item is like the type of reference, and the third a specific identifier to reference.