### PR TITLE
Adjust syntax for rewritten ShellScript

### DIFF
--- a/Bash (AzureDevops).sublime-syntax
+++ b/Bash (AzureDevops).sublime-syntax
@@ -16,3 +16,8 @@ contexts:
   string-prototype:
     - meta_prepend: true
     - include: scope:source.yaml.pipeline.azure-devops#string-interpolations
+
+variables:
+  # lazy escaping from heredoc as shell maybe indented
+  no_indent: ^\s*
+  tab_indent: ^\s*

--- a/Bash (Github Actions).sublime-syntax
+++ b/Bash (Github Actions).sublime-syntax
@@ -17,13 +17,21 @@ contexts:
     - include: scope:source.yaml.pipeline.github-actions#string-interpolations
 
   heredocs-body:
+    # before Packages PR #4024
     - meta_prepend: true
     - match: ^\s*\3$ # the third capture from redirections-here-document
       scope: meta.tag.heredoc.shell entity.name.tag.heredoc.shell
       pop: 1
 
   heredocs-body-no-expansion:
+    # before Packages PR #4024
     - meta_prepend: true
     - match: ^\s*\5$ # the fourth capture from redirections-here-document
       scope: meta.tag.heredoc.shell entity.name.tag.heredoc.shell
       pop: 1
+
+variables:
+  # requires Packages PR #4024
+  # lazy escaping from heredoc as shell maybe indented
+  no_indent: ^\s*
+  tab_indent: ^\s*

--- a/tests/syntax_test_github_actions.yml
+++ b/tests/syntax_test_github_actions.yml
@@ -230,7 +230,17 @@ jobs:
       - name: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#environment-files
         run: |
           echo '# Some Markdown Content Here' >> $GITHUB_STEP_SUMMARY
-#                                                ^^^^^^^^^^^^^^^^^^^^ variable.language.github-actions
+          #                                      ^^^^^^^^^^^^^^^^^^^^ variable.language.github-actions
+          echo <<EOF
+            # ${tilte}
+            # <- meta.string.heredoc.shell string.unquoted.heredoc.shell
+            # ^^^^^^^^ meta.string.heredoc.shell meta.interpolation.parameter.shell
+
+            $GITHUB_STEP_SUMMARY
+            # <- meta.string.heredoc.shell variable.language.github-actions punctuation.definition.variable.github-actions
+            #^^^^^^^^^^^^^^^^^^^ meta.string.heredoc.shell variable.language.github-actions
+          EOF
+          # <- meta.tag.heredoc.end.shell entity.name.tag.heredoc.shell
 
       - name: folded shell script command
         run: >-


### PR DESCRIPTION
This PR prepares YamlPipeline's extended Bash syntaxes for https://github.com/sublimehq/Packages/pull/4024 to ensure smooth transision.

Mait target is keeping HEREDOCs highlighted correctly, as `heredocs-body` and `heredocs-body-no-expansion` have been renamed and their escape handling has been made more "extending-friendly" by providing `no_indent` and `tab_indent` variables to control indentation restrictions.

This PR is backward compatible with current Bash syntax.