### PR TITLE
Folded blocks are indicated by `>`, not by the chomping indicator

### DIFF
--- a/YamlPipeline.sublime-syntax
+++ b/YamlPipeline.sublime-syntax
@@ -68,20 +68,19 @@ contexts:
 
   script-block-scalar:
     # http://www.yaml.org/spec/1.2/spec.html#style/block/scalar
-    # c-l+literal(n) | c-l+folded(n)
-    - match: (?:(\|)|(>))([1-9])?([-+])  # c-b-block-header(m,t)
+    # c-l+folded(n)
+    - match: (>)([1-9])?([-+]?)  # c-b-block-header(m,t)
       captures:
-        1: keyword.control.flow.block-scalar.literal.yaml
-        2: keyword.control.flow.block-scalar.folded.yaml
-        3: constant.numeric.indentation-indicator.yaml
-        4: storage.modifier.chomping-indicator.yaml
+        1: keyword.control.flow.block-scalar.folded.yaml
+        2: constant.numeric.indentation-indicator.yaml
+        3: storage.modifier.chomping-indicator.yaml
       set: script-block-folded-scalar-begin
-    - match: (?:(\|)|(>))([1-9])?  # c-b-block-header(m,t)
+    # c-l+literal(n)
+    - match: (\|)([1-9])?([-+]?)  # c-b-block-header(m,t)
       captures:
         1: keyword.control.flow.block-scalar.literal.yaml
-        2: keyword.control.flow.block-scalar.folded.yaml
-        3: constant.numeric.indentation-indicator.yaml
-        4: storage.modifier.chomping-indicator.yaml
+        2: constant.numeric.indentation-indicator.yaml
+        3: storage.modifier.chomping-indicator.yaml
       set: script-block-scalar-begin
 
 

--- a/tests/syntax_test_gitlab_cicd.yml
+++ b/tests/syntax_test_gitlab_cicd.yml
@@ -137,7 +137,9 @@ release-finish:
       when: manual
   script:
     - NEW_VERSION="${NEW_VERSION:-${CI_COMMIT_BRANCH#release/}}"
-    - >-
+    # folding block
+    - >
+      # <- keyword.control.flow.block-scalar.folded.yaml
       mvn
       --batch-mode
       # ^^^^^^^^^^ source.shell meta.function-call.arguments meta.parameter.option variable.parameter.option
@@ -153,7 +155,22 @@ release-finish:
       #                ^^^^^^^^^^^^^^^^ meta.string
       #                   ^^^^^^^^^^^ meta.interpolation.parameter variable.other.readwrite
       -DskipTestProject=true
-
+    # non-folding block
+    - |- # Add commit sha and "project-level internal id" for non-tag build since we cannot replace images.
+      # <- keyword.control.flow.block-scalar.literal.yaml
+      #^ storage.modifier.chomping-indicator.yaml
+      if [ -n $CI_COMMIT_TAG ]; then
+      # <- keyword.control.conditional.if.shell
+        export CLOUD_REGISTRY_TAG="${DOCKER_TAG}"
+      # ^^^^^^ support.function.shell
+      else
+      # <- keyword.control.conditional.else.shell
+        export CLOUD_REGISTRY_TAG="${DOCKER_TAG}-${CI_COMMIT_SHORT_SHA}-${CI_PIPELINE_IID}"
+      # ^^^^^^ support.function.shell
+      fi;
+      # ^ punctuation.terminator.statement.shell
+      echo $CLOUD_REGISTRY_TAG
+      # <- source.shell support.function
 include:
   - local: setup.yml
 


### PR DESCRIPTION
Fixes a regression from #22.

Took me a while to
1. notice this
2. become annoyed enough to look into a fix
3. actually fix it (this step was trivial)