### PR TITLE
Fix multiline script list items

### DIFF
--- a/AWSTemplate.sublime-syntax
+++ b/AWSTemplate.sublime-syntax
@@ -56,6 +56,7 @@ contexts:
       push: script-block-sequence
 
   script-block-sequence:
+    - meta_scope: meta.block.script.pipeline
     - match: |-
         (?x)^(\s+)(-)[ \t]+(?="CMD-SHELL"|'CMD-SHELL'|CMD-SHELL\b)
         (["'])?
@@ -71,21 +72,29 @@ contexts:
         - pop-at-bol
     - include: expect-script-block-node
 
-  pop-if-not-sequence-at-same-or-deeper-indentation:
-    - match: ^(?!\1\s*-)
-      pop: 1
-
   pop-at-bol:
     - match: ^
       pop: 1
 
   expect-script-block-node:
-    - match: (-)[ \t]+(?=\S)(["'])?
+    - meta_content_scope: meta.block.script.pipeline
+    # a list item followed by alias, macro or block scalar
+    - match: ^(\s*)(-)\s+(?=[\s*|>'"])
       captures:
-        1: punctuation.definition.block.sequence.item.yaml
-        2: punctuation.definition.string.begin.yaml
-      push: script-block-node
-    - include: pop-if-not-sequence-at-same-or-deeper-indentation
+        2: punctuation.definition.block.sequence.item.yaml
+      embed: script-block-node
+      embed_scope: meta.string.yaml
+      escape: ^(?!\1[ ]{2}|\s*#)
+    # a list item with unquoted folded multi-line shell script content
+    - match: ^(\s*)(-)\s+
+      captures:
+        2: punctuation.definition.block.sequence.item.yaml
+      embed: scope:source.shell.bash.folded
+      embed_scope: meta.string.yaml source.shell.bash.embedded
+      escape: ^(?!\1[ ]{2})
+    # pop if not sequence at same or deeper level
+    - match: ^(?!\1\s*-)
+      pop: 1
 
   script-block-node:
     - meta_prepend: true

--- a/AzureDevops.sublime-syntax
+++ b/AzureDevops.sublime-syntax
@@ -94,10 +94,10 @@ contexts:
 
   embedded-bash:
     - meta_include_prototype: false
-    - meta_scope: source.shell.bash.embedded
+    - meta_content_scope: source.shell.bash.embedded
     - include: scope:source.shell.bash.azure-devops
 
   embedded-bash-folded:
     - meta_include_prototype: false
-    - meta_scope: source.shell.bash.embedded
+    - meta_content_scope: source.shell.bash.embedded
     - include: scope:source.shell.bash.folded-azure-devops

--- a/Bitbucket Pipeline.sublime-syntax
+++ b/Bitbucket Pipeline.sublime-syntax
@@ -11,30 +11,41 @@ file_extensions:
 contexts:
   node:
     - meta_prepend: true
+    - match: ^\s+(name)\s*(:)\s+
+      captures:
+        1: meta.mapping.key.yaml meta.string.yaml string.unquoted.plain.out.yaml
+        2: punctuation.separator.key-value.yaml
+      push: meta-name
     - match: ^\s+(script)\s*(:)(?=\s|$)
       captures:
         1: string.unquoted.plain.out.yaml keyword.control.flow.script.pipeline
         2: punctuation.separator.key-value.yaml
       push: script-block-sequence
-    - match: ^\s+(name)\s*(:)\s*
-      captures:
-        1: meta.mapping.key.yaml meta.string.yaml string.unquoted.plain.out.yaml
-        2: punctuation.separator.key-value.yaml
-      push:
-        - meta-name
-
-
-  script-block-sequence:
-    - match: (-)[ \t]+(?=\S)
-      captures:
-        1: punctuation.definition.block.sequence.item.yaml
-      embed: scope:source.shell.bash
-      escape: '{{_flow_scalar_end_plain_out}}'
-    - match: (?=\S)
-      pop: 1
 
   meta-name:
     - meta_content_scope: entity.name.label.bitbucket
     - include: flow-scalar-in-12
     - match: ''
       pop: 1
+
+  script-block-sequence:
+    - meta_scope: meta.block.script.pipeline
+    # a list item followed by block scalar
+    - match: ^(\s*)(-)\s+(?=[\s|>])
+      captures:
+        2: punctuation.definition.block.sequence.item.yaml
+      embed: script-block-node
+      escape: ^(?!\1[ ]{2}|\s*#)
+    # a list item with shell script content
+    - match: ^(\s*)(-)\s+
+      captures:
+        2: punctuation.definition.block.sequence.item.yaml
+      embed: scope:source.shell.bash.folded
+      embed_scope: source.shell.bash.embedded
+      escape: ^(?!\1[ ]{2}|\s*#)
+    - match: ^
+      pop: 1
+
+  script-block-node:
+    - include: script-block-scalar
+    - include: flow-scalar-script-out

--- a/Bitbucket Pipeline.sublime-syntax
+++ b/Bitbucket Pipeline.sublime-syntax
@@ -16,10 +16,10 @@ contexts:
         1: meta.mapping.key.yaml meta.string.yaml string.unquoted.plain.out.yaml
         2: punctuation.separator.key-value.yaml
       push: meta-name
-    - match: ^\s+(script)\s*(:)(?=\s|$)
+    - match: ^(\s+)(script)\s*(:)(?=\s|$)
       captures:
-        1: string.unquoted.plain.out.yaml keyword.control.flow.script.pipeline
-        2: punctuation.separator.key-value.yaml
+        2: string.unquoted.plain.out.yaml keyword.control.flow.script.pipeline
+        3: punctuation.separator.key-value.yaml
       push: script-block-sequence
 
   meta-name:
@@ -35,15 +35,17 @@ contexts:
       captures:
         2: punctuation.definition.block.sequence.item.yaml
       embed: script-block-node
+      embed_scope: meta.string.yaml
       escape: ^(?!\1[ ]{2}|\s*#)
     # a list item with unquoted folded multi-line shell script content
     - match: ^(\s*)(-)\s+
       captures:
         2: punctuation.definition.block.sequence.item.yaml
       embed: scope:source.shell.bash.folded
-      embed_scope: source.shell.bash.embedded
-      escape: ^(?!\1[ ]{2}|\s*#)
-    - match: ^
+      embed_scope: meta.string.yaml source.shell.bash.embedded
+      escape: ^(?!\1[ ]{2})
+    # pop if not sequence at same or deeper level
+    - match: ^(?!\1\s*-)
       pop: 1
 
   script-block-node:

--- a/Bitbucket Pipeline.sublime-syntax
+++ b/Bitbucket Pipeline.sublime-syntax
@@ -31,12 +31,12 @@ contexts:
   script-block-sequence:
     - meta_scope: meta.block.script.pipeline
     # a list item followed by block scalar
-    - match: ^(\s*)(-)\s+(?=[\s|>])
+    - match: ^(\s*)(-)\s+(?=[\s|>'"])
       captures:
         2: punctuation.definition.block.sequence.item.yaml
       embed: script-block-node
       escape: ^(?!\1[ ]{2}|\s*#)
-    # a list item with shell script content
+    # a list item with unquoted folded multi-line shell script content
     - match: ^(\s*)(-)\s+
       captures:
         2: punctuation.definition.block.sequence.item.yaml
@@ -49,3 +49,13 @@ contexts:
   script-block-node:
     - include: script-block-scalar
     - include: flow-scalar-script-out
+
+  embedded-bash:
+    - meta_include_prototype: false
+    - meta_content_scope: source.shell.bash.embedded
+    - include: scope:source.shell.bash
+
+  embedded-bash-folded:
+    - meta_include_prototype: false
+    - meta_content_scope: source.shell.bash.embedded
+    - include: scope:source.shell.bash.folded

--- a/Bitbucket Pipeline.sublime-syntax
+++ b/Bitbucket Pipeline.sublime-syntax
@@ -35,6 +35,6 @@ contexts:
 
   meta-name:
     - meta_content_scope: entity.name.label.bitbucket
-    - include: flow-scalar-12
+    - include: flow-scalar-in-12
     - match: ''
       pop: 1

--- a/Gitlab CICD.sublime-syntax
+++ b/Gitlab CICD.sublime-syntax
@@ -39,20 +39,27 @@ contexts:
         2: punctuation.separator.key-value.yaml
 
   script-block-sequence:
-    - match: (-)[ \t]+(?=\S)
+    - meta_scope: meta.block.script.pipeline
+    # a list item followed by alias, macro or block scalar
+    - match: ^(\s*)(-)\s+(?=[\s*!|>])
       captures:
-        1: punctuation.definition.block.sequence.item.yaml
-      push: script-block-node
-    - match: ^(?=[ ]{2}\w)
-      pop: 1
-    - match: (?=\S)
+        2: punctuation.definition.block.sequence.item.yaml
+      embed: script-block-node
+      escape: ^(?!\1[ ]{2}|\s*#)
+    # a list item with shell script content
+    - match: ^(\s*)(-)\s+
+      captures:
+        2: punctuation.definition.block.sequence.item.yaml
+      embed: scope:source.shell.bash.folded
+      embed_scope: source.shell.bash.embedded
+      escape: ^(?!\1[ ]{2}|\s*#)
+    - match: ^
       pop: 1
 
   script-block-node:
-    - meta_prepend: true
     - include: flow-alias
-    - match: '{{_flow_scalar_end_plain_out}}'
-      pop: 1
+    - include: script-block-scalar
+    - include: flow-scalar-script-out
 
   embedded-bash:
     - meta_include_prototype: false

--- a/Gitlab CICD.sublime-syntax
+++ b/Gitlab CICD.sublime-syntax
@@ -41,12 +41,12 @@ contexts:
   script-block-sequence:
     - meta_scope: meta.block.script.pipeline
     # a list item followed by alias, macro or block scalar
-    - match: ^(\s*)(-)\s+(?=[\s*!|>])
+    - match: ^(\s*)(-)\s+(?=[\s*!|>'"])
       captures:
         2: punctuation.definition.block.sequence.item.yaml
       embed: script-block-node
       escape: ^(?!\1[ ]{2}|\s*#)
-    # a list item with shell script content
+    # a list item with unquoted folded multi-line shell script content
     - match: ^(\s*)(-)\s+
       captures:
         2: punctuation.definition.block.sequence.item.yaml
@@ -63,12 +63,12 @@ contexts:
 
   embedded-bash:
     - meta_include_prototype: false
-    - meta_scope: source.shell.bash.embedded
+    - meta_content_scope: source.shell.bash.embedded
     - include: scope:source.shell.bash
 
   embedded-bash-folded:
     - meta_include_prototype: false
-    - meta_scope: source.shell.bash.embedded
+    - meta_content_scope: source.shell.bash.embedded
     - include: scope:source.shell.bash.folded
 
   property:

--- a/Gitlab CICD.sublime-syntax
+++ b/Gitlab CICD.sublime-syntax
@@ -24,10 +24,10 @@ variables:
 contexts:
   node:
     - meta_prepend: true
-    - match: ^\s+(script|before_script|after_script)\s*(:)(?=\s|$)
+    - match: ^(\s+)(script|before_script|after_script)\s*(:)(?=\s|$)
       captures:
-        1: string.unquoted.plain.out.yaml keyword.control.flow.script.pipeline
-        2: punctuation.separator.key-value.yaml
+        2: string.unquoted.plain.out.yaml keyword.control.flow.script.pipeline
+        3: punctuation.separator.key-value.yaml
       push: script-block-sequence
     - match: ^({{global_keywords}})\s*(:)$
       captures:
@@ -45,15 +45,17 @@ contexts:
       captures:
         2: punctuation.definition.block.sequence.item.yaml
       embed: script-block-node
+      embed_scope: meta.string.yaml
       escape: ^(?!\1[ ]{2}|\s*#)
     # a list item with unquoted folded multi-line shell script content
     - match: ^(\s*)(-)\s+
       captures:
         2: punctuation.definition.block.sequence.item.yaml
       embed: scope:source.shell.bash.folded
-      embed_scope: source.shell.bash.embedded
-      escape: ^(?!\1[ ]{2}|\s*#)
-    - match: ^
+      embed_scope: meta.string.yaml source.shell.bash.embedded
+      escape: ^(?!\1[ ]{2})
+    # pop if not sequence at same or deeper level
+    - match: ^(?!\1\s*-)
       pop: 1
 
   script-block-node:

--- a/YamlPipeline.sublime-syntax
+++ b/YamlPipeline.sublime-syntax
@@ -83,16 +83,29 @@ contexts:
         3: storage.modifier.chomping-indicator.yaml
       set: script-block-scalar-begin
 
-
   flow-scalar-script-out:
+    # double quoted scalar
+    - match: \"
+      scope: meta.string.yaml string.quoted.double.yaml punctuation.definition.string.begin.yaml
+      embed: embedded-bash-folded
+      embed_scope: meta.string.yaml
+      escape: \"
+      escape_captures:
+        0: meta.string.yaml string.quoted.double.yaml punctuation.definition.string.end.yaml
+      pop: 1
+    # single quoted scalar
+    - match: \'
+      scope: meta.string.yaml string.quoted.single.yaml punctuation.definition.string.begin.yaml
+      embed: embedded-bash-folded
+      embed_scope: meta.string.yaml
+      escape: \'
+      escape_captures:
+        0: meta.string.yaml string.quoted.single.yaml punctuation.definition.string.end.yaml
+      pop: 1
+    # unquoted scalar
     - match: (?={{ns_plain_first_plain_out}})
-      set: flow-scalar-script-out-body
-
-  flow-scalar-script-out-body:
-    - meta_include_prototype: false
-    - meta_scope: meta.string.yaml string.unquoted.plain.out.yaml
-    - match: (?=\S)
-      embed: embedded-bash
+      embed: embedded-bash-folded
+      embed_scope: meta.string.yaml
       escape: '{{_flow_scalar_end_plain_out}}'
       pop: 1
 

--- a/tests/syntax_test_aws_buildspec.yaml
+++ b/tests/syntax_test_aws_buildspec.yaml
@@ -36,6 +36,19 @@ phases:
     commands:
       - echo Build started on `date`
       - echo Building the Docker image...
+      - docker build
+        # <- meta.string.yaml source.shell.bash.embedded meta.function-call.identifier.shell meta.command.shell variable.function.shell
+        #^^^^^^^^^^^ meta.string.yaml source.shell.bash.embedded
+        # <- meta.command.shell variable.function.shell
+        --target some_target
+        # <- meta.block.script.pipeline meta.string.yaml source.shell.bash.embedded meta.function-call.arguments.shell meta.parameter.option.shell variable.parameter.option.shell punctuation.definition.parameter.shell
+        #^^^^^^^^^^^^^^^^^^^^ meta.block.script.pipeline meta.string.yaml source.shell.bash.embedded meta.function-call.arguments.shell
+        #^^^^^^^ meta.parameter.option.shell variable.parameter.option.shell
+        #        ^^^^^^^^^^^ string.unquoted.shell
+        --tag $AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/${IMAGE_REPO_NAME}:${CI_DOCKER_VERSION}-predeploy
+        # <- meta.block.script.pipeline meta.string.yaml source.shell.bash.embedded meta.function-call.arguments.shell meta.parameter.option.shell variable.parameter.option.shell punctuation.definition.parameter.shell
+        #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.script.pipeline meta.string.yaml source.shell.bash.embedded meta.function-call.arguments.shell
+        #^^^^ meta.parameter.option.shell variable.parameter.option.shell
       - >-
 #     ^^^^ meta.block.script.pipeline
 #     ^ punctuation.definition.block.sequence.item.yaml

--- a/tests/syntax_test_bitbucket_pipeline.yml
+++ b/tests/syntax_test_bitbucket_pipeline.yml
@@ -18,10 +18,20 @@ pipelines:
       # Build and push image
 #     ^^^^^^^^^^^^^^^^^^^^^^^ comment.line.number-sign
       - VERSION="1.$BITBUCKET_BUILD_NUMBER"
+#     ^^ meta.block.script.pipeline - source.shell
+#       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.script.pipeline source.shell.bash.embedded
 #     ^ punctuation.definition.block.sequence.item
-#       ^^^^^^^ source.shell meta.variable variable.other.readwrite
-      - echo ${DOCKERHUB_PASSWORD} | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
-#                                                 ^^ variable.parameter.option punctuation.definition.parameter
+#       ^^^^^^^ variable.other.readwrite.shell
+#              ^ keyword.operator.assignment.shell
+#               ^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string
+      - echo ${DOCKERHUB_PASSWORD}
+        | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
+#       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.script.pipeline source.shell.bash.embedded
+#       ^ keyword.operator.assignment.pipe.shell
+#         ^^^^^^ meta.function-call.identifier.shell variable.function.shell
+#               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell
+#                      ^^ variable.parameter.option.shell punctuation.definition.parameter.shell
+#                        ^^^^^^^^ variable.parameter.option.shell - punctuation
       - IMAGE="$DOCKERHUB_USERNAME/$BITBUCKET_REPO_SLUG"
       - docker build -t ${IMAGE}:${VERSION} .
       - docker tag ${IMAGE}:${VERSION} ${IMAGE}:latest

--- a/tests/syntax_test_bitbucket_pipeline.yml
+++ b/tests/syntax_test_bitbucket_pipeline.yml
@@ -37,8 +37,18 @@ pipelines:
       - docker tag ${IMAGE}:${VERSION} ${IMAGE}:latest
       - docker push ${IMAGE}
       # Push tags
-      - git tag -a "${VERSION}" -m "Tagging for release ${VERSION}"
-      - git push origin ${VERSION}
+      - 'git tag -a "${VERSION}" -m
+        "Tagging for release ${VERSION}"'
+#       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.script.pipeline source.shell.bash.embedded meta.function-call.arguments.shell meta.string.glob.shell
+#                                       ^ meta.string.yaml string.quoted.single.yaml punctuation.definition.string.end.yaml - source.shell
+      - 'git push origin ${VERSION}'
+#     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.script.pipeline
+#     ^ punctuation.definition.block.sequence.item.yaml
+#       ^ meta.string.yaml string.quoted.single.yaml punctuation.definition.string.begin.yaml - source.shell
+#        ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.yaml source.shell.bash.embedded
+#        ^^^ meta.function-call.identifier.shell meta.command.shell variable.function.shell
+#           ^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell
+#                                  ^ meta.string.yaml string.quoted.single.yaml punctuation.definition.string.end.yaml - source.shell
       services:
 #     ^^^^^^^^ meta.mapping.key meta.string string.unquoted.plain.out - source.shell
       - docker

--- a/tests/syntax_test_gitlab_cicd.yml
+++ b/tests/syntax_test_gitlab_cicd.yml
@@ -14,19 +14,19 @@ build-job:
 #       ^ punctuation.separator.key-value
     - echo "Hello, $GITLAB_USER_LOGIN!"
 #   ^ punctuation.definition.block.sequence.item
-#     ^^^^ source.shell meta.function-call.identifier support.function.echo
+#     ^^^^ source.shell meta.function-call.identifier support.function
   after_script:
 # ^^^^^^^^^^^^ string.unquoted.plain.out keyword.control.flow.script
 #             ^ punctuation.separator.key-value
     - echo "Execute this command after the `script` section completes."
 #   ^ punctuation.definition.block.sequence.item
-#     ^^^^ source.shell meta.function-call.identifier support.function.echo
+#     ^^^^ source.shell meta.function-call.identifier support.function
   before_script:
 # ^^^^^^^^^^^^^ string.unquoted.plain.out keyword.control.flow.script
 #              ^ punctuation.separator.key-value
     - echo "Execute this `before_script` in all jobs by default."
 #   ^ punctuation.definition.block.sequence.item
-#     ^^^^ source.shell meta.function-call.identifier support.function.echo
+#     ^^^^ source.shell meta.function-call.identifier support.function
 
 # <- - source.shell
 test-job1:
@@ -38,17 +38,42 @@ test-job1:
 # ^^^^^^ string.unquoted.plain.out keyword.control.flow.script
 #       ^ punctuation.separator.key-value
     - echo "This job tests something"
-#   ^ punctuation.definition.block.sequence.item
+#^^^^^ meta.block.script.pipeline - source.shell
+#     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.script.pipeline source.shell.bash.embedded
 #^^^ - punctuation
+#   ^ punctuation.definition.block.sequence.item
 #    ^ - punctuation
+      "...with line continued here"
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.script.pipeline source.shell.bash.embedded
+#     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.glob.shell string.quoted.double.shell
+#     ^ punctuation.definition.string.begin.shell
+#                                 ^ punctuation.definition.string.end.shell
+    - var="$(echo "$CI_COMMIT_TAG"
+      | grep -Eo '\d+\.\d+\.\d+(-?(a(lpha)?|b(eta)?|rc)\.?\d+)?$'
+      || echo "$CI_COMMIT_REF_SLUG")"
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.script.pipeline source.shell.bash.embedded meta.string
+#     ^^ keyword.operator.logical.shell
+#        ^^^^ meta.function-call.identifier.shell support.function.shell
+#             ^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell meta.string
+#                                 ^ punctuation.definition.string.end.shell
+#                                  ^ punctuation.section.interpolation.end.shell
+#                                   ^ punctuation.definition.string.end.shell
   - |
-# ^ meta.block.script punctuation.definition.block.sequence.item
-#   ^ meta.block.script keyword.control.flow.block-scalar.literal
+# ^^^ meta.block.script.pipeline - meta.block.script meta.block.script - source.shell
+# ^ punctuation.definition.block.sequence.item
+#   ^ keyword.control.flow.block-scalar.literal
     echo "First command line."
-    #^^^ meta.function-call.identifier support.function.echo
+    # <- meta.block.script.pipeline source.shell.bash.embedded
+    #^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.script.pipeline source.shell.bash.embedded
+    #^^^ meta.function-call.identifier support.function
     echo "Second command line."
-    #^^^ meta.function-call.identifier support.function.echo
+    # <- meta.block.script.pipeline source.shell.bash.embedded
+    #^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.script.pipeline source.shell.bash.embedded
+    #^^^ meta.function-call.identifier support.function
     echo "Third command line."
+    # <- meta.block.script.pipeline source.shell.bash.embedded
+    #^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.script.pipeline source.shell.bash.embedded
+    #^^^ meta.function-call.identifier support.function
 
 test-job2:
 # <- - source.shell
@@ -118,13 +143,13 @@ deploy:
   extends: .npm-deploy-job
   before_script:
     - *set-gitlab-token
-#   ^ meta.block.script punctuation.definition.block.sequence.item
-#     ^ meta.block.script keyword.control.flow.alias punctuation.definition.alias
-#      ^^^^^^^^^^^^^^^^ meta.block.script variable.other.alias
+#   ^ meta.block.script punctuation.definition.block.sequence.item - meta.block.script meta.block.script
+#     ^ meta.block.script keyword.control.flow.alias punctuation.definition.alias - meta.block.script meta.block.script
+#      ^^^^^^^^^^^^^^^^ meta.block.script variable.other.alias - meta.block.script meta.block.script
     - *setup-node-modules
-#   ^ meta.block.script punctuation.definition.block.sequence.item
-#     ^ meta.block.script keyword.control.flow.alias punctuation.definition.alias
-#      ^^^^^^^^^^^^^^^^^^ meta.block.script variable.other.alias
+#   ^ meta.block.script punctuation.definition.block.sequence.item - meta.block.script meta.block.script
+#     ^ meta.block.script keyword.control.flow.alias punctuation.definition.alias - meta.block.script meta.block.script
+#      ^^^^^^^^^^^^^^^^^^ meta.block.script variable.other.alias - meta.block.script meta.block.script
     - *setup-gitlab-registry
   script:
     - npm publish --registry "https://gitlab.com/api/v4/projects/${CI_PROJECT_ID}/packages/npm/"
@@ -192,7 +217,7 @@ test:
 #                                ^ - meta.sequence
     - echo running my own command
 #   ^ meta.block.script punctuation.definition.block.sequence.item
-#     ^^^^ source.shell.bash meta.function-call.identifier support.function.echo
+#     ^^^^ source.shell.bash meta.function-call.identifier support.function
   after_script:
     - !reference [.teardown, after_script]
 

--- a/tests/syntax_test_gitlab_cicd.yml
+++ b/tests/syntax_test_gitlab_cicd.yml
@@ -43,11 +43,13 @@ test-job1:
 #^^^ - punctuation
 #   ^ punctuation.definition.block.sequence.item
 #    ^ - punctuation
+    - echo "This job tests something"
+      # <- meta.block.script.pipeline meta.string.yaml source.shell.bash.embedded meta.function-call.identifier.shell support.function.shell
+      #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.script.pipeline meta.string.yaml source.shell.bash.embedded
       "...with line continued here"
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.script.pipeline source.shell.bash.embedded
-#     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.glob.shell string.quoted.double.shell
-#     ^ punctuation.definition.string.begin.shell
-#                                 ^ punctuation.definition.string.end.shell
+      #^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.script.pipeline meta.string.yaml source.shell.bash.embedded meta.function-call.arguments.shell meta.string.glob.shell string.quoted.double.shell
+      # <- punctuation.definition.string.begin.shell
+      #                           ^ punctuation.definition.string.end.shell
     - var="$(echo "$CI_COMMIT_TAG"
       | grep -Eo '\d+\.\d+\.\d+(-?(a(lpha)?|b(eta)?|rc)\.?\d+)?$'
       || echo "$CI_COMMIT_REF_SLUG")"

--- a/tests/syntax_test_gitlab_cicd.yml
+++ b/tests/syntax_test_gitlab_cicd.yml
@@ -58,6 +58,23 @@ test-job1:
 #                                 ^ punctuation.definition.string.end.shell
 #                                  ^ punctuation.section.interpolation.end.shell
 #                                   ^ punctuation.definition.string.end.shell
+    - 'echo "\$RENOVATE_EXTRA_FLAGS: $RENOVATE_EXTRA_FLAGS"'
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.block.script.pipeline
+#     ^ meta.string.yaml string.quoted.single.yaml punctuation.definition.string.begin.yaml - source.shell
+#      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.yaml source.shell.bash.embedded
+#                                                          ^ meta.string.yaml string.quoted.single.yaml - source.shell
+#      ^^^^ meta.function-call.identifier.shell support.function.shell
+#          ^ meta.function-call.arguments.shell - meta.function-call meta.string
+#           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell meta.string.glob.shell
+#                                                         ^ punctuation.definition.string.end.shell
+#                                                          ^ punctuation.definition.string.end.yaml
+    - 'echo "\$RENOVATE_EXTRA_FLAGS:
+      # <- meta.string.yaml string.quoted.single.yaml punctuation.definition.string.begin.yaml - source.shell
+      # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.string.yaml source.shell.bash.embedded
+      $RENOVATE_EXTRA_FLAGS"'
+#     ^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments.shell meta.string.glob.shell
+#                          ^ punctuation.definition.string.end.shell
+#                           ^ meta.string.yaml string.quoted.single.yaml punctuation.definition.string.end.yaml - source.shell
   - |
 # ^^^ meta.block.script.pipeline - meta.block.script meta.block.script - source.shell
 # ^ punctuation.definition.block.sequence.item


### PR DESCRIPTION
Resolves #30
Resolves #35

This PR updates BitBucket and Gitlab syntaxes to support multi-line script commands.

A YAML list item may contain multiple lines of content. Linefeeds are removed when loading it.

This means, items with script commands behave like folded block scripts. All lines are merged into a single command before evaluating it.

Choosen implementation assumes sane usage of list items, which excludes implicitly nested lists such as...

```
script:
  - - - command
```

It instead expects to see single `-`, only:
 
```
script:
  - command
```