### PR TITLE
Add PowerShell support

### DIFF
--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -24,7 +24,7 @@ jobs:
         include:
           - build: 4200
             packages: binary
-            powershell: st4107-5.0.3
+            powershell: st4107-5.1.1
           - build: latest
             packages: master
             powershell: master

--- a/Embeddings/PowerShell (Folded).sublime-syntax
+++ b/Embeddings/PowerShell (Folded).sublime-syntax
@@ -1,0 +1,13 @@
+%YAML 1.2
+---
+# See http://www.sublimetext.com/docs/syntax.html
+scope: source.powershell.folded
+version: 2
+hidden: true
+
+extends: Packages/PowerShell/PowerShell.sublime-syntax
+
+contexts:
+  pop-eol: []
+
+  pop-before-eol: []

--- a/Embeddings/PowerShell (Github Actions Folded).sublime-syntax
+++ b/Embeddings/PowerShell (Github Actions Folded).sublime-syntax
@@ -1,0 +1,10 @@
+%YAML 1.2
+---
+name: PowerShell (Github Actions Folded)
+scope: source.powershell.folded-github-actions
+version: 2
+hidden: true
+
+extends:
+  - PowerShell (Folded).sublime-syntax
+  - PowerShell (Github Actions).sublime-syntax

--- a/Embeddings/PowerShell (Github Actions).sublime-syntax
+++ b/Embeddings/PowerShell (Github Actions).sublime-syntax
@@ -1,0 +1,13 @@
+%YAML 1.2
+---
+name: PowerShell (Github Actions)
+scope: source.powershell.github-actions
+version: 2
+hidden: true
+
+extends: Packages/PowerShell/PowerShell.sublime-syntax
+
+variables:
+  # lazy escaping from heredoc as shell maybe indented
+  no_indent: ^\s*
+  tab_indent: ^\s*

--- a/Github Actions.sublime-syntax
+++ b/Github Actions.sublime-syntax
@@ -9,6 +9,11 @@ extends: Packages/YamlPipelines/YamlPipeline.sublime-syntax
 contexts:
   node:
     - meta_prepend: true
+    - match: \s+(shell)\s*(:)(?=\s|$)
+      captures:
+        1: string.unquoted.plain.out.yaml keyword.control.shell.pipeline
+        2: punctuation.separator.key-value.yaml
+      push: expect-shell-name
     - match: \s+(run|inlineScript)\s*(:)(?=\s|$)
       captures:
         1: string.unquoted.plain.out.yaml keyword.control.flow.script.pipeline
@@ -38,6 +43,37 @@ contexts:
         1: string.unquoted.plain.out.yaml keyword.declaration.class.pipeline
         2: punctuation.separator.key-value.yaml
       push: expect-jobs
+
+  expect-shell-name:
+    - match: \b(?i:pwsh|powershell)\b
+      scope: constant.other.language-name.yaml
+      set: pwsh-step
+    - match: \b[\w-]+\b
+      scope: constant.other.language-name.yaml
+      pop: 1
+    - match: ^
+      pop: 1
+
+  pwsh-step:
+    # bailout at end of step
+    # - either next step
+    # - or next job
+    - match: ^(?=\s*-|\s{,2}\S)
+      pop: 1
+    # switch shell syntax (just in case of duplicate definitions)
+    - match: \s+(shell)\s*(:)(?=\s|$)
+      captures:
+        1: string.unquoted.plain.out.yaml keyword.control.conditional.dependencies.pipeline
+        2: punctuation.separator.key-value.yaml
+      set: expect-shell-name
+    # consume single script block with powershell syntax
+    - match: \s+(run|inlineScript)\s*(:)(?=\s|$)
+      captures:
+        1: string.unquoted.plain.out.yaml keyword.control.flow.script.pipeline
+        2: punctuation.separator.key-value.yaml
+      set: pwsh-block-node
+    # consume ordinary nodes
+    - include: node
 
   inside-if:
     - meta_include_prototype: false
@@ -73,11 +109,25 @@ contexts:
     - meta_include_prototype: false
     - meta_content_scope: source.shell.bash.embedded
     - include: scope:source.shell.bash.github-actions
+      apply_prototype: true
 
   embedded-bash-folded:
     - meta_include_prototype: false
     - meta_content_scope: source.shell.bash.embedded
     - include: scope:source.shell.bash.folded-github-actions
+      apply_prototype: true
+
+  embedded-pwsh:
+    - meta_include_prototype: false
+    - meta_content_scope: source.powershell.embedded
+    - include: scope:source.powershell.github-actions
+      apply_prototype: true
+
+  embedded-pwsh-folded:
+    - meta_include_prototype: false
+    - meta_content_scope: source.powershell.embedded
+    - include: scope:source.powershell.folded-github-actions
+      apply_prototype: true
 
   expect-jobs:
     - match: ^(\s*)([\w\-]+)\s*(:)(?=\s|$)

--- a/YamlPipeline.sublime-syntax
+++ b/YamlPipeline.sublime-syntax
@@ -63,6 +63,84 @@ contexts:
       scope: punctuation.separator.argument.pipeline
     - include: inside-expression
 
+###[ POWERSHELL SCRIPT BLOCKS ]################################################
+
+  pwsh-block-node:
+    - meta_scope: meta.block.pwsh.pipeline
+    - include: pwsh-block-scalar
+    - include: flow-scalar-pwsh-out
+
+  pwsh-block-scalar:
+    # http://www.yaml.org/spec/1.2/spec.html#style/block/scalar
+    # c-l+folded(n)
+    - match: (>)([1-9])?([-+]?)  # c-b-block-header(m,t)
+      captures:
+        1: keyword.control.flow.block-scalar.folded.yaml
+        2: constant.numeric.indentation-indicator.yaml
+        3: storage.modifier.chomping-indicator.yaml
+      set: pwsh-block-folded-scalar-begin
+    # c-l+literal(n)
+    - match: (\|)([1-9])?([-+]?)  # c-b-block-header(m,t)
+      captures:
+        1: keyword.control.flow.block-scalar.literal.yaml
+        2: constant.numeric.indentation-indicator.yaml
+        3: storage.modifier.chomping-indicator.yaml
+      set: pwsh-block-scalar-begin
+
+  flow-scalar-pwsh-out:
+    # double quoted scalar
+    - match: \"
+      scope: meta.string.yaml string.quoted.double.yaml punctuation.definition.string.begin.yaml
+      embed: embedded-pwsh-folded
+      embed_scope: meta.string.yaml
+      escape: \"
+      escape_captures:
+        0: meta.string.yaml string.quoted.double.yaml punctuation.definition.string.end.yaml
+      pop: 1
+    # single quoted scalar
+    - match: \'
+      scope: meta.string.yaml string.quoted.single.yaml punctuation.definition.string.begin.yaml
+      embed: embedded-pwsh-folded
+      embed_scope: meta.string.yaml
+      escape: \'
+      escape_captures:
+        0: meta.string.yaml string.quoted.single.yaml punctuation.definition.string.end.yaml
+      pop: 1
+    # unquoted scalar
+    - match: (?={{ns_plain_first_plain_out}})
+      embed: embedded-pwsh-folded
+      embed_scope: meta.string.yaml
+      escape: '{{_flow_scalar_end_plain_out}}'
+      pop: 1
+
+  pwsh-block-scalar-begin:
+    - meta_include_prototype: false
+    - include: comment
+    - match: ^([ ]+)(?! )  # match first non-empty line to determine indentation level
+      scope: source.powershell.embedded
+      # note that we do not check if indentation is enough
+      embed: embedded-pwsh
+      escape: ^(?!\1|\s*$)
+      pop: 1
+    - match: ^(?=\S)  # the block is empty
+      pop: 1
+    - match: .+
+      scope: invalid.illegal.expected-comment-or-newline.yaml
+
+  pwsh-block-folded-scalar-begin:
+    - meta_include_prototype: false
+    - include: comment
+    - match: ^([ ]+)(?! )  # match first non-empty line to determine indentation level
+      scope: source.powershell.embedded
+      # note that we do not check if indentation is enough
+      embed: embedded-pwsh-folded
+      escape: ^(?!\1|\s*$)
+      pop: 1
+    - match: ^(?=\S)  # the block is empty
+      pop: 1
+    - match: .+
+      scope: invalid.illegal.expected-comment-or-newline.yaml
+
 ###[ SHELLSCRIPT SCRIPT BLOCKS ]###############################################
 
   script-block-node:
@@ -189,4 +267,10 @@ contexts:
     - meta_include_prototype: false
 
   embedded-bash-folded:
+    - meta_include_prototype: false
+
+  embedded-pwsh:
+    - meta_include_prototype: false
+
+  embedded-pwsh-folded:
     - meta_include_prototype: false

--- a/tests/syntax_test_github_actions.yml
+++ b/tests/syntax_test_github_actions.yml
@@ -90,6 +90,14 @@ jobs:
 
     steps:
 
+      - name: Test leading source.powershell
+        shell: pwsh
+        run: |
+          Write-Output Test
+# <- source.powershell.embedded
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.powershell.embedded - source.powershell source.powershell
+#         ^^^^^^^^^^^^ support.function
+
       - name: Test leading source.shell
         run: |
           echo Test
@@ -219,6 +227,31 @@ jobs:
         EOF
         # ^ entity.name.tag.heredoc.shell
         )
+
+    - name: Run Powershell
+      shell: pwsh
+#     ^^^^^ string.unquoted.plain.out.yaml keyword.control.shell.pipeline
+#          ^ punctuation.separator.key-value.yaml
+#            ^^^^ constant.other.language-name.yaml
+      if: true
+#     ^^ string.unquoted.plain.out.yaml keyword.control.flow.condition.pipeline
+#       ^ punctuation.separator.key-value.yaml
+#         ^^^^ constant.language.boolean.pipeline
+      run: |
+        $heredoc = @'
+          A HEREDOC string
+        '@;
+        # <- source.powershell.embedded meta.string.powershell string.quoted.single.heredoc.powershell punctuation.definition.string.end.powershell
+        #^ source.powershell.embedded meta.string.powershell string.quoted.single.heredoc.powershell punctuation.definition.string.end.powershell
+        #
+        $job = Get-Process -Name pwsh
+        # <- source.powershell.embedded variable.other.readwrite.powershell punctuation.definition.variable.powershell
+        #^^^ source.powershell.embedded variable.other.readwrite.powershell
+
+    - name: Bash is the default
+      run: |
+        ls .
+#^^^^^^^^^^^^ source.shell.bash.embedded
 
   job_foobar:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
This PR adds support for powershell scripts in Github Action steps.

Example:

```yml
    - name "Powershell Step" 
      shell: pwsh
      run: |
         Write-Output "Highlighted with Powershell syntax"
```

Note: requires PowerShell v5.1.1+ (ST4107 - 4200) or v6.2.1+ (ST4205+).
